### PR TITLE
Add a settings option for projects.cfg

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -14,7 +14,6 @@ namespace Flow.Launcher.Plugin.Godot
     public class Godot : IPlugin, ISettingProvider, IContextMenu
     {
         private const string GodotIconPath = "Assets\\Godot.png";
-        private string ProjectsConfigPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Godot", "projects.cfg");
         private PluginInitContext _context;
         private List<GodotProject> projects;
         private Settings _settings;
@@ -34,7 +33,7 @@ namespace Flow.Launcher.Plugin.Godot
         {
             projects = new List<GodotProject>();
             string currentSection = null;
-            using StreamReader reader = new StreamReader(ProjectsConfigPath);
+            using StreamReader reader = new StreamReader(_settings.ProjectsConfigPath);
             string line;
             while ((line = reader.ReadLine()) != null)
             {
@@ -168,4 +167,13 @@ public class GodotProject
     public string Name { get; set; }
     public string ProjectPath { get; set; }
     public bool Favorite { get; set; }
+}
+public class Settings
+{
+    public string GodotExecutablePath { get; set; } = string.Empty;
+    public string ProjectsConfigPath { get; set; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Godot",
+        "projects.cfg"
+    );
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -1,6 +1,23 @@
-﻿namespace Flow.Launcher.Plugin.Godot;
+﻿using System;
+using System.IO;
+
+namespace Flow.Launcher.Plugin.Godot;
 
 public class Settings
 {
     public string GodotExecutablePath{ get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the Godot projects configuration file.
+    /// By default, this is set to the "projects.cfg" file located in the
+    /// user's application data directory under the "Godot" folder.
+    ///
+    /// Some installation methods, like Steam, may place this file
+    /// in a different location.
+    /// </summary>
+    public string ProjectsConfigPath { get; set; } = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), 
+        "Godot",
+        "projects.cfg"
+    );
 }

--- a/Views/GodotLauncherSettings.xaml
+++ b/Views/GodotLauncherSettings.xaml
@@ -13,7 +13,7 @@
             <TextBox Name="GodotDirectoryTextBox" Margin="10"/>
             
             <TextBlock Text="Projects Config Path" Margin="10"/>
-            <TextBox Name="ProjectsConfigTextBox Margin="10"></TextBox>
+            <TextBox Name="ProjectsConfigTextBox" Margin="10"/>
             <Button Content="Save" Click="Button_Click" Margin="10,5,10,10"/>
         </StackPanel>
     </StackPanel>

--- a/Views/GodotLauncherSettings.xaml
+++ b/Views/GodotLauncherSettings.xaml
@@ -11,6 +11,9 @@
         <StackPanel Margin="10">
             <TextBlock Text="Godot Executable Path" Margin="10"/>
             <TextBox Name="GodotDirectoryTextBox" Margin="10"/>
+            
+            <TextBlock Text="Projects Config Path" Margin="10"/>
+            <TextBox Name="ProjectsConfigTextBox"></TextBox>
             <Button Content="Save" Click="Button_Click" Margin="10,5,10,10"/>
         </StackPanel>
     </StackPanel>

--- a/Views/GodotLauncherSettings.xaml
+++ b/Views/GodotLauncherSettings.xaml
@@ -13,7 +13,7 @@
             <TextBox Name="GodotDirectoryTextBox" Margin="10"/>
             
             <TextBlock Text="Projects Config Path" Margin="10"/>
-            <TextBox Name="ProjectsConfigTextBox"></TextBox>
+            <TextBox Name="ProjectsConfigTextBox Margin="10"></TextBox>
             <Button Content="Save" Click="Button_Click" Margin="10,5,10,10"/>
         </StackPanel>
     </StackPanel>

--- a/Views/GodotLauncherSettings.xaml.cs
+++ b/Views/GodotLauncherSettings.xaml.cs
@@ -32,12 +32,14 @@ namespace Flow.Launcher.Plugin.Godot
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            GodotDirectoryTextBox.Text = _settings.GodotExecutablePath ?? "Excecutable path Not Set";
+            GodotDirectoryTextBox.Text = _settings.GodotExecutablePath ?? "Executable path Not Set";
+            ProjectsConfigTextBox.Text = _settings.ProjectsConfigPath ?? "Path to projects.cfg Not Set";
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             _settings.GodotExecutablePath = GodotDirectoryTextBox.Text;
+            _settings.ProjectsConfigPath = ProjectsConfigTextBox.Text;
             _context.API.SaveSettingJsonStorage<Settings>();
         }
     }


### PR DESCRIPTION
# Allow customization of projects.cfg path location

## Problem
When Godot is installed through Steam or other distribution methods, the `projects.cfg` file may be located in a different directory than the default ApplicationData/Godot location. This makes the plugin unusable for users with non-standard Godot installations.

## Changes
- Moved `ProjectsConfigPath` from hardcoded property in `Godot.cs` to user-configurable setting in `Settings.cs`
- Added new text input field in settings panel to allow users to modify the projects.cfg path
- Maintained the default path (AppData/Godot/projects.cfg) for standard installations
- Added XML documentation to explain the setting's purpose

![Godot Plugin for Flow Launcher](https://github.com/user-attachments/assets/5dbf8092-56ab-41cd-ac94-6e054c632842)

## Testing
- [x] Plugin works with default Godot installation
- [x] Plugin works with Steam Godot installation after path configuration
- [x] Settings are persisted between Flow Launcher sessions
- [x] Invalid paths are handled gracefully

## Notes for users
If you installed Godot through Steam or another method that places configuration files in non-standard locations, you can now specify the correct path to your `projects.cfg` file through the plugin settings.
